### PR TITLE
feat: 支出・収入の合計を表示

### DIFF
--- a/src/components/MonthlyBalance.tsx
+++ b/src/components/MonthlyBalance.tsx
@@ -1,29 +1,52 @@
-import { Stack, Text } from '@chakra-ui/react'
+import { Stack, Text, VStack } from '@chakra-ui/react'
 import React from 'react'
 
 import { Item } from '../hooks/useIncomeExpense'
+import { IncomeExpenseDisplayItem } from './item/IncomeExpenseDisplayItem'
 // ______________________________________________________
 //
-type ContainerProps = Omit<Props, 'incomeExpenseAmount' | 'moneyColor'>
+type ContainerProps = Omit<
+  Props,
+  'incomeExpenseAmount' | 'moneyColor' | 'incomeItemsAmount' | 'expenseItemsAmount'
+>
 
 type Props = {
   expenseItems: Item[]
+  expenseItemsAmount: number
   incomeExpenseAmount: number
   incomeItems: Item[]
+  incomeItemsAmount: number
   moneyColor: string
 }
 // ______________________________________________________
 //
 const Component: React.FC<Props> = (props) => (
-  <Stack>
-    <Text fontSize={'30px'} fontWeight={'bold'}>
-      - 収支合計 -
-    </Text>
-    <Text borderBottom={'1px solid #000'} color={props.moneyColor} fontSize={'40px'}>
-      {props.incomeExpenseAmount.toLocaleString()}
-      <Text as={'span'}>円</Text>
-    </Text>
-  </Stack>
+  <VStack borderBottom={'1px solid #000'} pb={2} spacing={'6'} width={'100%'}>
+    <VStack>
+      <Text fontSize={'30px'} fontWeight={'bold'}>
+        - 残高 -
+      </Text>
+      <Text color={props.moneyColor} fontSize={'40px'} fontWeight={'bold'} width={'100%'}>
+        {props.incomeExpenseAmount.toLocaleString()}
+        <Text as={'span'} fontSize={'30px'} fontWeight={'normal'}>
+          円
+        </Text>
+      </Text>
+    </VStack>
+    {/* 収支を表示する */}
+    <Stack direction={{ base: 'column', lg: 'row' }} spacing={'8'}>
+      <IncomeExpenseDisplayItem
+        label={'支出'}
+        labelColor={'red.400'}
+        totalAmount={props.expenseItemsAmount}
+      />
+      <IncomeExpenseDisplayItem
+        label={'収入'}
+        labelColor={'green.500'}
+        totalAmount={props.incomeItemsAmount}
+      />
+    </Stack>
+  </VStack>
 )
 // ______________________________________________________
 //
@@ -37,7 +60,17 @@ const Container: React.FC<ContainerProps> = (props) => {
 
   const moneyColor = incomeExpenseAmount < 0 ? 'red.500' : 'blue.600'
 
-  return <Component {...props} incomeExpenseAmount={incomeExpenseAmount} moneyColor={moneyColor} />
+  console.log('収入', incomeItemsAmount)
+  console.log('支出', expenseItemsAmount)
+  return (
+    <Component
+      {...props}
+      expenseItemsAmount={expenseItemsAmount}
+      incomeExpenseAmount={incomeExpenseAmount}
+      incomeItemsAmount={incomeItemsAmount}
+      moneyColor={moneyColor}
+    />
+  )
 }
 // ______________________________________________________
 //

--- a/src/components/item/IncomeExpenseDisplayItem.tsx
+++ b/src/components/item/IncomeExpenseDisplayItem.tsx
@@ -1,0 +1,43 @@
+import { Text, VStack } from '@chakra-ui/react'
+import React from 'react'
+
+// ______________________________________________________
+//
+type ContainerProps = Omit<
+  Props,
+  'incomeExpenseAmount' | 'moneyColor' | 'incomeItemsAmount' | 'expenseItemsAmount'
+>
+
+type Props = {
+  label: string
+  labelColor: string
+  totalAmount: number
+}
+// ______________________________________________________
+//
+const Component: React.FC<Props> = (props) => (
+  <VStack
+    align={'center'}
+    backgroundColor={props.labelColor}
+    borderRadius={'5px'}
+    color={'#fff'}
+    flexDirection={{ base: 'row', lg: 'row' }}
+    justifyContent={'center'}
+    padding={'0.5rem'}
+    spacing={'4'}
+    width={'300px'}
+  >
+    <Text color={'#000'} fontSize={'18px'}>
+      {props.label}
+    </Text>
+    <Text fontSize={'26px'}>{`${props.totalAmount.toLocaleString()}円`}</Text>
+  </VStack>
+)
+// ______________________________________________________
+//
+const Container: React.FC<ContainerProps> = (props) => {
+  return <Component {...props} />
+}
+// ______________________________________________________
+//
+export const IncomeExpenseDisplayItem = Container


### PR DESCRIPTION
close #23 

### 概要
支出・収入の合計を表示エリアを実装した

グラフの実装で収支の合計は計算していたので特に計算の実装は不要。
エリアを適当なデザインで実装した
やっぱりデザインは難しい...

![image](https://github.com/Tomo-kw/my-budget-app/assets/68243050/c9f78eea-3ec4-4126-bc3c-b77394a86da1)
